### PR TITLE
feat: add BHM gold/black gradients for Leadership and Breakout Sessions

### DIFF
--- a/src/components/speakers/SpeakersContent.jsx
+++ b/src/components/speakers/SpeakersContent.jsx
@@ -126,7 +126,7 @@ const SpeakersContent = ({ year, defaultExpanded }) => {
       {renderSpeakerHeader}
       {renderSpeakerDescription}
       <div
-        className={`overflow-hidden transition-all duration-500 ease-in-out ${
+        className={`mx-auto max-w-[2000px] overflow-hidden transition-all duration-500 ease-in-out ${
           isExpanded ? 'max-h-none opacity-100' : 'max-h-0 opacity-0'
         }`}
       >

--- a/src/components/ui/ProfileCard.jsx
+++ b/src/components/ui/ProfileCard.jsx
@@ -28,11 +28,11 @@ const ProfileCard = ({
       'Build with AI': 'bg-purple-800',
       Innovation: 'bg-indigo-800',
       'Level Up': 'bg-emerald-800',
-      Leadership: 'bg-bhm-gold-500',
+      Leadership: 'bg-bhm-gold-800',
       'Tech+Design': 'bg-red-800',
       Workshops: 'bg-orange-800',
       'AI Foundations': 'bg-red-800',
-      'Breakout Sessions': 'bg-bhm-black-900',
+      'Breakout Sessions': 'bg-bhm-black-800',
     }
 
     if (track) return trackColors[track] || 'bg-red-700'
@@ -53,8 +53,8 @@ const ProfileCard = ({
       'bg-indigo-800': 'from-indigo-400/60 via-indigo-400/5',
       'bg-red-800': 'from-red-400/60 via-red-400/5',
       'bg-orange-900': 'from-orange-400/60 via-orange-400/5',
-      'bg-bhm-gold-500': 'from-bhm-gold-400/60 via-bhm-gold-400/5',
-      'bg-bhm-black-900': 'from-bhm-black-800/60 via-bhm-black-800/5',
+      'bg-bhm-gold-800': 'from-bhm-gold-400/60 via-bhm-gold-400/5',
+      'bg-bhm-black-800': 'from-bhm-black-800/60 via-bhm-black-800/5',
 
       // Legacy/fallback colors
       'bg-primary-300': 'from-primary-300/60 via-primary-300/5',

--- a/src/components/ui/ProfileCard.jsx
+++ b/src/components/ui/ProfileCard.jsx
@@ -28,10 +28,11 @@ const ProfileCard = ({
       'Build with AI': 'bg-purple-800',
       Innovation: 'bg-indigo-800',
       'Level Up': 'bg-emerald-800',
-      Leadership: 'bg-sky-800',
+      Leadership: 'bg-bhm-gold-500',
       'Tech+Design': 'bg-red-800',
       Workshops: 'bg-orange-800',
       'AI Foundations': 'bg-red-800',
+      'Breakout Sessions': 'bg-bhm-black-900',
     }
 
     if (track) return trackColors[track] || 'bg-red-700'
@@ -52,6 +53,8 @@ const ProfileCard = ({
       'bg-indigo-800': 'from-indigo-400/60 via-indigo-400/5',
       'bg-red-800': 'from-red-400/60 via-red-400/5',
       'bg-orange-900': 'from-orange-400/60 via-orange-400/5',
+      'bg-bhm-gold-500': 'from-bhm-gold-400/60 via-bhm-gold-400/5',
+      'bg-bhm-black-900': 'from-bhm-black-800/60 via-bhm-black-800/5',
 
       // Legacy/fallback colors
       'bg-primary-300': 'from-primary-300/60 via-primary-300/5',


### PR DESCRIPTION
# Pull Request

## Description

Adds Black History Month–aligned color styling for Leadership and Breakout Sessions speaker cards.

- Maps Leadership to BHM gold for badge and image gradients
- Maps Breakout Sessions to BHM black for badge and image gradients
- Adds matching gradient entries for `bg-bhm-gold-500` and `bg-bhm-black-900`
- Fixes track name mismatch causing Breakout Sessions to fall back to red

This improves visual consistency with the BHM design system while preserving accessibility and existing layouts.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Accessibility improvement

## Related Issues

N/A

## Code Quality Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [x] Code is properly commented where necessary
- [x] No console.log statements left in the code
- [x] No hardcoded values that should be configurable
- [x] Error handling is implemented where appropriate

## Testing

- [x] Changes have been tested locally
- [x] All existing tests pass (if applicable)
- [ ] New tests have been added for new functionality (if applicable)
- [x] Manual testing has been performed
- [x] Accessibility testing has been performed (for UI changes)

## Accessibility (for UI changes)

- [x] All interactive elements are keyboard accessible
- [x] Color contrast meets WCAG AA standards
- [x] Images have appropriate alt text
- [x] Focus indicators are visible

## Build & Deployment

- [x] Application builds successfully
- [x] No build warnings or errors
- [x] No security vulnerabilities introduced

## Screenshots (if applicable)

Added screenshots showing Leadership (gold) and Breakout Sessions (black) cards.

## Additional Notes

Colors follow the Black History Month palette guidelines:
- Leadership → gold (excellence & celebration)
- Breakout Sessions → black (identity & strength)

Gradients use lighter tonal overlays to keep speaker images readable.

---
