### PR TITLE
fix(previous-events): fix background and extra bottom spacing

### DIFF
--- a/src/pages/PreviousEvents.jsx
+++ b/src/pages/PreviousEvents.jsx
@@ -12,7 +12,7 @@ const PreviousEvents = () => {
     <PageLayout>
       <section
         aria-labelledby="main-heading"
-        className={`bg-inherit pt-72 transition-[opacity,transform] duration-1000 ease-out ${
+        className={`mb-[-224px] bg-bhm-gold-100 pt-72 transition-[opacity,transform] duration-1000 ease-out dark:bg-bhm-gold-100 ${
           isVisible ? '-translate-y-56 opacity-100' : 'translate-y-24 opacity-0'
         }`}
       >


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the Previous Events page to use a consistent light tan background and removes the extra empty space at the bottom caused by the slide-up transition.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Accessibility improvement
- [ ] Other (please describe):

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" -->
N/A

## Code Quality Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of the code has been performed
- [ ] Code is properly commented where necessary
- [x] No console.log statements left in the code
- [x] No hardcoded values that should be configurable
- [ ] Error handling is implemented where appropriate

## Testing

- [x] Changes have been tested locally
- [x] All existing tests pass (if applicable)
- [ ] New tests have been added for new functionality (if applicable)
- [x] Manual testing has been performed
- [ ] Accessibility testing has been performed (for UI changes)

## Accessibility (for UI changes)

- [x] All interactive elements are keyboard accessible
- [x] Color contrast meets WCAG AA standards
- [ ] Images have appropriate alt text
- [ ] Form labels are properly associated
- [x] Focus indicators are visible
- [ ] Screen reader compatibility has been tested

## Build & Deployment

- [x] Application builds successfully
- [x] No build warnings or errors
- [x] Dependencies are up to date
- [x] No security vulnerabilities introduced

## Screenshots (if applicable)
Before
<img width="1493" height="797" alt="image" src="https://github.com/user-attachments/assets/407f6413-53fb-429c-b98c-b9ea1c455223" />
<img width="1556" height="741" alt="image" src="https://github.com/user-attachments/assets/7692d8f7-1931-4742-9ddc-4bc02f8d5279" />


After
<img width="1561" height="914" alt="image" src="https://github.com/user-attachments/assets/bd49e7bd-057c-4886-90d1-44375bc4fd93" />
<img width="1554" height="578" alt="image" src="https://github.com/user-attachments/assets/3f8b6207-a1cd-42c5-ade9-1332479419f1" />


## Additional Notes

The bottom gap was caused by translating the page content without affecting layout height. This PR compensates for that so the footer sits correctly after the transition.